### PR TITLE
chore: add new adjustment param to getBarsV2

### DIFF
--- a/@types/params.d.ts
+++ b/@types/params.d.ts
@@ -64,6 +64,7 @@ export interface GetBars {
     limit?: number;
     page_token?: string;
     timeframe: '1Sec' | '1Min' | '1Hour' | '1Day';
+    adjustment?: 'both' | 'dividend' | 'raw' | 'split';
 }
 export interface GetBars_v1 {
     timeframe: string;

--- a/src/params.ts
+++ b/src/params.ts
@@ -78,6 +78,7 @@ export interface GetBars {
   limit?: number
   page_token?: string
   timeframe: '1Sec' | '1Min' | '1Hour' | '1Day'
+  adjustment?: 'both' | 'dividend' | 'raw' | 'split'
 }
 
 export interface GetBars_v1 {


### PR DESCRIPTION
Add missing `adjustment` param found references [here](https://github.com/alpacahq/alpaca-trade-api-js/blob/6df4efd39473a85107e0e17471467388a3177bd4/lib/resources/datav2/rest_v2.ts#L239).

Supported values: `raw`, `split`, `dividend`, `both`

This param is critical in supporting adjusted historical data such as split and dividends.