### PR TITLE
fix: correct `both` with `all` adjustment param

### DIFF
--- a/@types/params.d.ts
+++ b/@types/params.d.ts
@@ -64,7 +64,7 @@ export interface GetBars {
     limit?: number;
     page_token?: string;
     timeframe: '1Sec' | '1Min' | '1Hour' | '1Day';
-    adjustment?: 'both' | 'dividend' | 'raw' | 'split';
+    adjustment?: 'all' | 'dividend' | 'raw' | 'split';
 }
 export interface GetBars_v1 {
     timeframe: string;

--- a/src/params.ts
+++ b/src/params.ts
@@ -78,7 +78,7 @@ export interface GetBars {
   limit?: number
   page_token?: string
   timeframe: '1Sec' | '1Min' | '1Hour' | '1Day'
-  adjustment?: 'both' | 'dividend' | 'raw' | 'split'
+  adjustment?: 'all' | 'dividend' | 'raw' | 'split'
 }
 
 export interface GetBars_v1 {


### PR DESCRIPTION
Hey sorry, for whatever reason one of the params actually didn't work or is outdated. `both` should actually be `all`. Tried all 4 param types of `all`, `split`, `dividend` and `raw` and confirmed that they all work.