### PR TITLE
feat: update asset type definition

### DIFF
--- a/src/entities.ts
+++ b/src/entities.ts
@@ -341,6 +341,11 @@ export interface Asset {
   symbol: string;
 
   /**
+   * Asset name
+   */
+  name: string;  
+
+  /**
    * active or inactive
    */
   status: AssetStatus;
@@ -354,6 +359,11 @@ export interface Asset {
    * Asset is marginable or not
    */
   marginable: boolean;
+
+  /**
+   * Margin requirement for maintenance of the asset
+   */
+  maintenance_margin_requirement: number;
 
   /**
    * Asset is shortable or not

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -303,6 +303,8 @@ export interface AggregateMinute {
   e: number;
 }
 
+export type AssetAttributes = [] | ['ptp_no_exception'] | ['ptp_with_exception']
+ 
 export type AssetExchange =
   | 'AMEX'
   | 'ARCA'
@@ -380,6 +382,11 @@ export interface Asset {
    * Asset is fractionable or not.
    */
   fractionable: boolean;
+
+  /**
+   * One of ptp_no_exception or ptp_with_exception if available, empty otherwise
+   */
+  attributes: AssetAttributes
 }
 
 /**


### PR DESCRIPTION
The **Asset** type is not up-to-date with the actual data returned (see example below). This PR updates it.

This is the actual data I receive:

```
    {
        "id": "85aca3f6-b4f2-435b-b4b8-37faa9b10085",
        "class": "us_equity",
        "exchange": "NYSE",
        "symbol": "GRP.U",
        "name": "GRANITE REAL ESTATE INVESTMENT TRUST",
        "status": "active",
        "tradable": true,
        "marginable": true,
        "maintenance_margin_requirement": 30,
        "shortable": true,
        "easy_to_borrow": true,
        "fractionable": false,
        "attributes": [
            "ptp_with_exception"
        ]
    }
```

Reference: [Alpaca docs for the asset entity](https://alpaca.markets/docs/api-references/trading-api/assets/#asset-entity)