### PR TITLE
add `side` param to getOrders

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -123,6 +123,7 @@ export interface GetOrders {
   until?: Date;
   direction?: 'asc' | 'desc';
   nested?: boolean;
+  side?: 'buy' | 'sell';
   symbols?: string[];
 }
 


### PR DESCRIPTION
getOrders was missing `side` param which can be either `buy` or `sell. https://docs.alpaca.markets/reference/getallorders